### PR TITLE
add Python pyd client to make D talk to Python server

### DIFF
--- a/examples/SimpleDemo/README.md
+++ b/examples/SimpleDemo/README.md
@@ -19,3 +19,14 @@ Now test D client
 ```
 $ ./client
 ```
+
+
+# Python pyd client
+
+First make sure you have pyd (>= version 0.14.1) installed
+```
+$ cd source
+$ make pyd
+$ make run
+Hello client_pyd
+```

--- a/examples/SimpleDemo/source/Makefile
+++ b/examples/SimpleDemo/source/Makefile
@@ -1,0 +1,7 @@
+
+run:
+	python3 client_pyd_test.py
+
+pyd:
+	$(RM) -fr build
+	python3 setup.py build

--- a/examples/SimpleDemo/source/client_pyd.d
+++ b/examples/SimpleDemo/source/client_pyd.d
@@ -1,0 +1,51 @@
+module client_pyd;
+
+import pyd.pyd;
+
+import helloworld.helloworld;
+import helloworld.helloworldrpc;
+
+import grpc;
+import hunt.logging;
+import std.stdio;
+
+
+class PydGreeterClient {
+  string host = "127.0.0.1";
+  ushort port = 30051;
+  GreeterClient client;
+
+  this() {
+    auto channel = new Channel(host, port);
+    client = new GreeterClient(channel);
+  }
+
+  auto SayHello(string name) {
+    HelloReply reply;
+    HelloRequest request = new HelloRequest();
+    request.name = name;
+    try {
+      reply = client.SayHello(request);
+    } catch (Exception e) {  //connection error
+      error(e);
+    }
+    return reply; //.message;
+  }
+}
+
+// python3 setup.py build
+
+extern(C) void PydMain() {
+    module_init();
+
+    wrap_class!(
+        helloworld.helloworld.HelloReply,
+	Member!("message", Mode!"rw")
+    )();
+
+    wrap_class!(
+        PydGreeterClient,
+        Init!(),
+        Def!(PydGreeterClient.SayHello)
+    )();
+}

--- a/examples/SimpleDemo/source/client_pyd_test.py
+++ b/examples/SimpleDemo/source/client_pyd_test.py
@@ -1,0 +1,26 @@
+import os.path, sys
+import distutils.util
+
+from pprint import pprint
+
+
+# Append the directory in which the binaries were placed to Python's sys.path,
+# then import the D DLL.
+libDir = os.path.join('build', 'lib.%s-%s' % (
+    distutils.util.get_platform(),
+    '.'.join(str(v) for v in sys.version_info[:2])
+))
+sys.path.append(os.path.abspath(libDir))
+
+import client_pyd
+
+
+
+if __name__ == "__main__":
+  client = client_pyd.PydGreeterClient()
+  reply = client.SayHello("client_pyd")
+  # pprint(vars(reply))
+  print(reply.message) # 
+  print(type(reply.message))
+  assert(reply.message == 'Hello client_pyd')
+  sys.exit(0)

--- a/examples/SimpleDemo/source/setup.py
+++ b/examples/SimpleDemo/source/setup.py
@@ -1,0 +1,40 @@
+from os.path import expanduser
+
+import glob
+from pyd.support import setup, Extension
+
+projName = 'client_pyd'
+
+home = expanduser("~")
+pyd_dir = '/usr/local/lib/python3.6/dist-packages/pyd/infrastructure/util/'
+
+include_dirs=[
+    "../../../source/",
+    pyd_dir,
+    home + "/.dub/packages/protobuf-0.6.2/protobuf/src/",
+    home + "/.dub/packages/hunt-1.6.14/hunt/source/",
+    home + "/.dub/packages/hunt-http-0.6.15/hunt-http/source/",
+    home + "/.dub/packages/hunt-extra-1.0.10/hunt-extra/source/",
+    home + "/.dub/packages/hunt-net-0.5.13/hunt-net/source/",
+    ]
+
+pkg_files = []
+for pkg in include_dirs:
+  pkg_files.extend(list(glob.glob(pkg + '**/*.d', recursive=True)))
+# print(pkg_files)
+
+setup(
+    name=projName,
+    version='0.1',
+    ext_modules=[
+        Extension(projName, [
+            'client_pyd.d',
+            "./helloworld/helloworld.d",
+            './helloworld/helloworldrpc.d',
+            ] + pkg_files,
+            # include_dirs=include_dirs,
+            extra_compile_args=['-version=HAVE_EPOLL'],
+            build_deimos=True,
+            d_lump=True)
+    ],
+)


### PR DESCRIPTION
At least it's working :-)

As a work-around for https://github.com/huntlabs/grpc-dlang/issues/15

```
$ make pyd
$ make run
python3 client_pyd_test.py
2021-May-18 12:16:28.4029315 | 458 | info | GrpcClient.connect | host : 127.0.0.1 port :30051 | ../../../source/grpc/GrpcClient.d:75
2021-05-18 12:16:28 (458) [warning] get - The field does not exist: :authority: 127.0.0.1:30051 - /root/.dub/packages/hunt-http-0.6.15/hunt-http/source/hunt/http/codec/http/hpack/HpackContext.d:218
2021-05-18 12:16:28 (458) [warning] get - The field does not exist: :path: /helloworld.Greeter/SayHello - /root/.dub/packages/hunt-http-0.6.15/hunt-http/source/hunt/http/codec/http/hpack/HpackContext.d:218
Hello client_pyd
<class 'str'>
```

@Heromyth BTW, why I have to press Ctrl+C to exit from the `client_pyd_test.py` ?

https://github.com/huntlabs/grpc-dlang/pull/19/files#diff-8dc489f595fc8b90139525ff80c93751e3454d0dcd4a4e4c3b61cf7c3bc66bd5R26